### PR TITLE
Wrap unsub subject to be compatible with ngx-auto-unsubscribe

### DIFF
--- a/src/take-until-destroy.ts
+++ b/src/take-until-destroy.ts
@@ -14,9 +14,9 @@ export const untilDestroyed = (
     componentInstance['__takeUntilDestroy'] || new Subject();
 
   componentInstance[destroyMethodName] = function() {
-    isFunction(originalDestroy) && originalDestroy.apply(this, arguments);
     componentInstance['__takeUntilDestroy'].next(true);
     componentInstance['__takeUntilDestroy'].complete();
+    isFunction(originalDestroy) && originalDestroy.apply(this, arguments);
   };
 
   return source.pipe(takeUntil<T>(componentInstance['__takeUntilDestroy']));


### PR DESCRIPTION
Wrapping the unsubscribe subject in an object "hides" it from the @AutoUnsubscribe decorator in the ngx-auto-unsubscribe project and allows the two libraries to work together seamlessly.