### PR TITLE
[Feat] Add @AutoUnsubscribe decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,22 @@ export class InboxComponent implements OnInit, OnDestroy {
 }
 ```
 
+### Use with decorator
+
+```ts
+import { AutoUnsubscribe } from 'ngx-take-until-destroy';
+
+@Component({...})
+class MyComponent implements OnDestroy {
+  @AutoUnsubscribe()
+  stream$ = interval(1000); // Now you can safely subscribe to it from anywhere
+
+  // This method must be present, even if empty.
+  ngOnDestroy() {}
+}
+```
+```
+
 ### Use with any class
 
 ```ts


### PR DESCRIPTION
Allows to apply `untilDestroyed` operator directly on class property streams:

```ts
@Component({...})
class MyComponent implements OnDestroy {
  @AutoUnsubscribe()
  stream$ = new Observable(...);

  // OnDestroy method is required by Angular Compiler
  ngOnDestroy() {}
}
```