### PR TITLE
[Feat] Add @WithUntilDestroyed decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ export class InboxComponent implements OnInit, OnDestroy {
 }
 ```
 
+## Usage
+
+```ts
+import { AutoUnsubscribe } from 'ngx-take-until-destroy';
+
+@Component({...})
+class MyComponent implements OnDestroy {
+  @AutoUnsubscribe()
+  stream$ = new Observable(...);
+
+  // This method must be present, even if empty
+  ngOnDestroy() {}
+}
+```
+
 ### Use with any class
 
 ```ts

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ import { AutoUnsubscribe } from 'ngx-take-until-destroy';
 @Component({...})
 class MyComponent implements OnDestroy {
   @AutoUnsubscribe()
-  stream$ = new Observable(...);
+  stream$ = interval(1000); // You can safely subscribe to this everywhere
 
   // This method must be present, even if empty
   ngOnDestroy() {}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ export class InboxComponent implements OnInit, OnDestroy {
 }
 ```
 
-## Usage
+### Use with decorator
 
 ```ts
 import { AutoUnsubscribe } from 'ngx-take-until-destroy';

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ import { untilDestroyed } from 'ngx-take-until-destroy';
 
 @Component({
   selector: 'app-inbox',
-  templateUrl: './inbox.component.html'
+  templateUrl: './inbox.component.html',
 })
 export class InboxComponent implements OnInit, OnDestroy {
   ngOnInit() {
@@ -37,11 +37,11 @@ export class InboxComponent implements OnInit, OnDestroy {
 ### Use with decorator
 
 ```ts
-import { AutoUnsubscribe } from 'ngx-take-until-destroy';
+import { WithUntilDestroyed } from 'ngx-take-until-destroy';
 
 @Component({...})
 class MyComponent implements OnDestroy {
-  @AutoUnsubscribe()
+  @WithUntilDestroyed()
   stream$ = interval(1000); // You can safely subscribe to this everywhere
 
   // This method must be present, even if empty

--- a/__tests__/decorator.ts
+++ b/__tests__/decorator.ts
@@ -22,7 +22,7 @@ describe('@WithUntilDestroyed decorator', () => {
 
     class Test {
       @WithUntilDestroyed('destroy')
-      notObservable = EMPTY;
+      stream$ = EMPTY;
 
       destroy() {}
     }

--- a/__tests__/decorator.ts
+++ b/__tests__/decorator.ts
@@ -1,0 +1,62 @@
+import { EMPTY, Subject } from 'rxjs';
+
+import * as untilDestroyedObj from '../src/take-until-destroy';
+
+import { WithUntilDestroyed } from '../src/decorator';
+
+describe('@WithUntilDestroyed decorator', () => {
+  it('should throw when applied on non Observable prop', () => {
+    class Test {
+      @WithUntilDestroyed()
+      notObservable = true;
+    }
+
+    expect(() => new Test()).toThrowError();
+  });
+
+  it('should call `untilDestroyed()` with target prototype and `destroyMethodName` on setter', () => {
+    const untilDestroyedSpy = spyOn(
+      untilDestroyedObj,
+      'untilDestroyed',
+    ).and.callThrough();
+
+    class Test {
+      @WithUntilDestroyed('destroy')
+      notObservable = EMPTY;
+
+      destroy() {}
+    }
+
+    expect(untilDestroyedSpy).not.toHaveBeenCalled();
+
+    new Test();
+
+    expect(untilDestroyedSpy).toHaveBeenCalledWith(Test.prototype, 'destroy');
+  });
+
+  it('should unsubscribe when `destroyMethodName` was called', () => {
+    const callback = jest.fn();
+
+    class Test {
+      subject = new Subject<any>();
+
+      @WithUntilDestroyed('destroy')
+      stream$ = this.subject.asObservable();
+
+      destroy() {}
+    }
+
+    const test = new Test();
+    test.stream$.subscribe(callback);
+
+    test.subject.next('event');
+
+    expect(callback).toHaveBeenCalledWith('event');
+
+    callback.mockReset();
+    test.destroy();
+    test.subject.next('event');
+
+    expect(callback).not.toHaveBeenCalled();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     },
     "testRegex": "/__tests__/.*\\.(ts|js)$"
   },
+  "peerDependencies": {
+    "rxjs": "^6.0.0"
+  },
   "devDependencies": {
     "@angular/compiler": "^6.1.9",
     "@angular/compiler-cli": "^6.1.9",

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,13 +1,15 @@
+import { isObservable, Observable } from 'rxjs';
+
 import { untilDestroyed } from './take-until-destroy';
 
 /**
- * Autamatically unsubscribes from pipe when component destroyed.
+ * Automatically unsubscribes from pipe when component destroyed.
  *
  * @example
  * ```ts
  * @Component({...})
  * class MyComponent implements OnDestroy {
- *   @AutoUnsubscribe()
+ *   @WithUntilDestroyed()
  *   stream$ = new Observable(...);
  *
  *   // OnDestroy method is required by Angular Compiler
@@ -19,15 +21,34 @@ import { untilDestroyed } from './take-until-destroy';
  *
  * Do not forget to implement {@link OnDestroy} life-cycle hook.
  */
-export function AutoUnsubscribe(destroyMethodName?: string): PropertyDecorator {
+export function WithUntilDestroyed(
+  destroyMethodName?: string,
+): PropertyDecorator {
   return (target, propKey) => {
-    const originalProp = target[propKey];
+    let val: Observable<any>;
+
+    function getter() {
+      return val;
+    }
+
+    function setter(newVal) {
+      if (isObservable(newVal)) {
+        val = newVal.pipe(untilDestroyed(target, destroyMethodName));
+      } else {
+        throw Error(
+          `WithUntilDestroyed: Property ${String(propKey)} on ${
+            target.constructor.name
+          } is not Observable!`,
+        );
+      }
+    }
 
     if (delete target[propKey]) {
       Object.defineProperty(target, propKey, {
         enumerable: true,
         configurable: true,
-        value: (originalProp as Observable<any>).pipe(untilDestroyed(target)),
+        set: setter,
+        get: getter,
       });
     }
   };

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,0 +1,34 @@
+import { untilDestroyed } from './take-until-destroy';
+
+/**
+ * Autamatically unsubscribes from pipe when component destroyed.
+ *
+ * @example
+ * ```ts
+ * @Component({...})
+ * class MyComponent implements OnDestroy {
+ *   @AutoUnsubscribe()
+ *   stream$ = new Observable(...);
+ *
+ *   // OnDestroy method is required by Angular Compiler
+ *   ngOnDestroy() {}
+ * }
+ * ```
+ *
+ * Uses {@link untilDestroyed} operator on the pipe.
+ *
+ * Do not forget to implement {@link OnDestroy} life-cycle hook.
+ */
+export function AutoUnsubscribe(destroyMethodName?: string): PropertyDecorator {
+  return (target, propKey) => {
+    const originalProp = target[propKey];
+
+    if (delete target[propKey]) {
+      Object.defineProperty(target, propKey, {
+        enumerable: true,
+        configurable: true,
+        value: originalProp.pipe(untilDestroyed(target)),
+      });
+    }
+  };
+}

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -27,7 +27,7 @@ export function AutoUnsubscribe(destroyMethodName?: string): PropertyDecorator {
       Object.defineProperty(target, propKey, {
         enumerable: true,
         configurable: true,
-        value: originalProp.pipe(untilDestroyed(target)),
+        value: (originalProp as Observable<any>).pipe(untilDestroyed(target)),
       });
     }
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { untilDestroyed } from './take-until-destroy';
-export { AutoUnsubscribe } from './decorator';
+export { WithUntilDestroyed as AutoUnsubscribe } from './decorator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
 export { untilDestroyed } from './take-until-destroy';
+export { AutoUnsubscribe } from './decorator';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,2 @@
 export { untilDestroyed } from './take-until-destroy';
-export { WithUntilDestroyed as AutoUnsubscribe } from './decorator';
+export { WithUntilDestroyed } from './decorator';


### PR DESCRIPTION
Allows to apply `untilDestroyed` operator directly on class property streams:

```ts
@Component({...})
class MyComponent implements OnDestroy {
  @WithUntilDestroyed()
  stream$ = new Observable(...);

  // OnDestroy method is required by Angular Compiler
  ngOnDestroy() {}
}
```