### PR TITLE
[Fix] Use component instance instead of prototype in WithUntilDestroyed decorator

### DIFF
--- a/__tests__/decorator.ts
+++ b/__tests__/decorator.ts
@@ -1,8 +1,7 @@
 import { EMPTY, Subject } from 'rxjs';
 
-import * as untilDestroyedObj from '../src/take-until-destroy';
-
 import { WithUntilDestroyed } from '../src/decorator';
+import * as untilDestroyedObj from '../src/take-until-destroy';
 
 describe('@WithUntilDestroyed decorator', () => {
   it('should throw when applied on non Observable prop', () => {
@@ -14,7 +13,7 @@ describe('@WithUntilDestroyed decorator', () => {
     expect(() => new Test()).toThrowError();
   });
 
-  it('should call `untilDestroyed()` with target prototype and `destroyMethodName` on setter', () => {
+  it('should call `untilDestroyed()` with instance and `destroyMethodName` on setter', () => {
     const untilDestroyedSpy = spyOn(
       untilDestroyedObj,
       'untilDestroyed',
@@ -29,9 +28,9 @@ describe('@WithUntilDestroyed decorator', () => {
 
     expect(untilDestroyedSpy).not.toHaveBeenCalled();
 
-    new Test();
+    const test = new Test();
 
-    expect(untilDestroyedSpy).toHaveBeenCalledWith(Test.prototype, 'destroy');
+    expect(untilDestroyedSpy).toHaveBeenCalledWith(test, 'destroy');
   });
 
   it('should unsubscribe when `destroyMethodName` was called', () => {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -33,7 +33,7 @@ export function WithUntilDestroyed(
 
     function setter(newVal) {
       if (isObservable(newVal)) {
-        val = newVal.pipe(untilDestroyed(target, destroyMethodName));
+        val = newVal.pipe(untilDestroyed(this, destroyMethodName));
       } else {
         throw Error(
           `WithUntilDestroyed: Property ${String(propKey)} on ${


### PR DESCRIPTION
I tested the decorator in real project and `@WithUntilDestroyed` decorator was not actually unsubscribing on component destruction.

I investigated what was happening and realised that it was operating on component prototype and not it's instance.

This PR now resolved the bug and it's successfully unsubscribes on destruction now.
