### PR TITLE
fix(decorator): do not override props with same name

### DIFF
--- a/__tests__/decorator.ts
+++ b/__tests__/decorator.ts
@@ -1,4 +1,4 @@
-import { EMPTY, Subject } from 'rxjs';
+import { EMPTY, Observable, Subject } from 'rxjs';
 
 import { WithUntilDestroyed } from '../src/decorator';
 import * as untilDestroyedObj from '../src/take-until-destroy';
@@ -57,5 +57,19 @@ describe('@WithUntilDestroyed decorator', () => {
     test.subject.next('event');
 
     expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('should not share value between instances', () => {
+    class Test {
+      @WithUntilDestroyed()
+      stream$ = new Observable();
+
+      ngOnDestroy() {}
+    }
+
+    const t1 = new Test();
+    const t2 = new Test();
+
+    expect(t1.stream$).not.toBe(t2.stream$);
   });
 });


### PR DESCRIPTION
Previously values were stored in function scope which lead to values with same name being overridden with the last value.

Now every property is stored on it's own object instance that is hidden from enumeration.

Added a test case that shows the issue (P.S. It was failing before the fix (= ).